### PR TITLE
Expand wijzigingen en ZGW 1.5.1

### DIFF
--- a/config/container.php
+++ b/config/container.php
@@ -150,6 +150,15 @@ return [
     'expand_enabled' => function (Container $container) {
         return (bool) $container->make('gf.setting', ['-zgw-expand']);
     },
+    'expand_version' => function (Container $container) {
+        switch ($container->make('gf.setting', ['-zgw-expand'])) {
+            case '1':
+                return '1.5.0';
+            case '2':
+                return '1.5.1';
+        }
+        return false;
+    },
 
     /**
      * Utilize with $container->make('gf.setting', ['setting-name-here']);

--- a/src/Endpoints/Traits/SupportsExpand.php
+++ b/src/Endpoints/Traits/SupportsExpand.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace OWC\Zaaksysteem\Endpoints\Traits;
 
-use OWC\Zaaksysteem\Endpoints\ZakenEndpoint;
 use OWC\Zaaksysteem\Foundation\Plugin;
+use OWC\Zaaksysteem\Endpoints\ZakenEndpoint;
+use OWC\Zaaksysteem\Resolvers\ContainerResolver;
 
 trait SupportsExpand
 {
@@ -87,14 +88,14 @@ trait SupportsExpand
     public function expandIsEnabled(): bool
     {
         return $this->expandEnabled &&
-            Plugin::getInstance()->getContainer()->get('expand_enabled');
+            ContainerResolver::make()->get('expand_enabled');
     }
 
     public function expandAll(): self
     {
         $this->expandEnabled = true;
 
-        $expandVersion = Plugin::getInstance()->getContainer()->get('expand_version');
+        $expandVersion = ContainerResolver::make()->get('expand_version');
 
         $this->expandCurrent[get_class($this)] = $this->expandSupport[get_class($this)][$expandVersion];
 
@@ -114,7 +115,7 @@ trait SupportsExpand
             return $this;
         }
 
-        $expandVersion = Plugin::getInstance()->getContainer()->get('expand_version');
+        $expandVersion = ContainerResolver::make()->get('expand_version');
 
         $this->expandCurrent[get_class($this)] = array_diff(
             $this->expandSupport[get_class($this)][$expandVersion],
@@ -130,7 +131,7 @@ trait SupportsExpand
             return $this;
         }
 
-        $expandVersion = Plugin::getInstance()->getContainer()->get('expand_version');
+        $expandVersion = ContainerResolver::make()->get('expand_version');
 
         $this->expandCurrent[get_class($this)] = array_intersect(
             $this->expandSupport[get_class($this)][$expandVersion],

--- a/src/Endpoints/Traits/SupportsExpand.php
+++ b/src/Endpoints/Traits/SupportsExpand.php
@@ -14,15 +14,13 @@ trait SupportsExpand
 
     /**
      * The current resources that will be expanded
-     * @var array
      */
-    protected $expandCurrent = [
+    protected array $expandCurrent = [
         ZakenEndpoint::class => ['zaaktype', 'status']
     ];
 
     /**
      * All supported expandable resources, subdivided by endpoint and ZGW version.
-     * @var array
      */
     protected array $expandSupport = [
         ZakenEndpoint::class => [

--- a/src/Endpoints/Traits/SupportsExpand.php
+++ b/src/Endpoints/Traits/SupportsExpand.php
@@ -11,14 +11,58 @@ trait SupportsExpand
 {
     protected bool $expandEnabled = true;
 
-    protected $expandSupport = [
-        ZakenEndpoint::class => [ // ZakenAPI
-            'zaaktype',
-            'status',
-            'status.statustype',
-            'hoofdzaak.status.statustype',
-            'hoofdzaak.deelzaken.status.statustype',
-        ],
+    /**
+     * The current resources that will be expanded
+     * @var array
+     */
+    protected $expandCurrent = [
+        ZakenEndpoint::class => ['zaaktype', 'status']
+    ];
+
+    /**
+     * All supported expandable resources, subdivided by endpoint and ZGW version.
+     * @var array
+     */
+    protected array $expandSupport = [
+        ZakenEndpoint::class => [
+            '1.5.0' => [
+                'zaaktype', 'status', 'status.statustype',
+                'hoofdzaak.status.statustype', 'hoofdzaak.deelzaken.status.statustype'
+            ],
+            '1.5.1' => [
+                'deelzaken',
+                'deelzaken.resultaat',
+                'deelzaken.resultaat.resultaattype',
+                'deelzaken.rollen',
+                'deelzaken.rollen.roltype',
+                'deelzaken.status',
+                'deelzaken.status.statustype',
+                'deelzaken.zaakinformatieobjecten',
+                'deelzaken.zaakobjecten',
+                'deelzaken.zaaktype',
+                'eigenschappen',
+                'eigenschappen.eigenschap',
+                'hoofdzaak',
+                'hoofdzaak.resultaat',
+                'hoofdzaak.resultaat.resultaattype',
+                'hoofdzaak.rollen',
+                'hoofdzaak.rollen.roltype',
+                'hoofdzaak.status',
+                'hoofdzaak.status.statustype',
+                'hoofdzaak.zaakinformatieobjecten',
+                'hoofdzaak.zaakobjecten',
+                'hoofdzaak.zaaktype',
+                'resultaat',
+                'resultaat.resultaattype',
+                'rollen',
+                'rollen.roltype',
+                'status',
+                'status.statustype',
+                'zaakinformatieobjecten',
+                'zaakobjecten',
+                'zaaktype',
+            ],
+        ]
         /**
          * The next endpoints do support the expand functionality,
          * but have yet to be tested.
@@ -39,6 +83,7 @@ trait SupportsExpand
         // ],
     ];
 
+
     public function expandIsEnabled(): bool
     {
         return $this->expandEnabled &&
@@ -48,6 +93,10 @@ trait SupportsExpand
     public function expandAll(): self
     {
         $this->expandEnabled = true;
+
+        $expandVersion = Plugin::getInstance()->getContainer()->get('expand_version');
+
+        $this->expandCurrent[get_class($this)] = $this->expandSupport[get_class($this)][$expandVersion];
 
         return $this;
     }
@@ -65,7 +114,12 @@ trait SupportsExpand
             return $this;
         }
 
-        $this->expandSupport[get_class($this)] = array_diff($this->expandSupport[get_class($this)], $resources);
+        $expandVersion = Plugin::getInstance()->getContainer()->get('expand_version');
+
+        $this->expandCurrent[get_class($this)] = array_diff(
+            $this->expandSupport[get_class($this)][$expandVersion],
+            $resources
+        );
 
         return $this;
     }
@@ -76,7 +130,12 @@ trait SupportsExpand
             return $this;
         }
 
-        $this->expandSupport[get_class($this)] = array_intersect($this->expandSupport[get_class($this)], $resources);
+        $expandVersion = Plugin::getInstance()->getContainer()->get('expand_version');
+
+        $this->expandCurrent[get_class($this)] = array_intersect(
+            $this->expandSupport[get_class($this)][$expandVersion],
+            $resources
+        );
 
         return $this;
     }
@@ -93,6 +152,6 @@ trait SupportsExpand
             return [];
         }
 
-        return $this->expandSupport[get_class($this)];
+        return $this->expandCurrent[get_class($this)];
     }
 }

--- a/src/Entities/Casts/Lazy/Statustype.php
+++ b/src/Entities/Casts/Lazy/Statustype.php
@@ -10,7 +10,7 @@ use function OWC\Zaaksysteem\Foundation\Helpers\resolve;
 
 class Statustype extends Resource
 {
-    protected string $resourceType = ZaakEntity::class;
+    protected string $resourceType = StatustypeEntity::class;
 
     protected function resolveResource(string $uuid): ?StatustypeEntity
     {

--- a/src/GravityForms/GravityFormsAddon.php
+++ b/src/GravityForms/GravityFormsAddon.php
@@ -108,7 +108,7 @@ class GravityFormsAddon extends GFAddOn
                 [
                     'name' => "{$this->prefix}-zgw-expand",
                     'default_value' => '0',
-                    'tooltip' => '<h6>' . __('Expand functionaliteit', 'owc-gravityforms-zaaksysteem') . '</h6>' . __('Verhoog de laadsnelheid door de expand functionaliteit te activeren. Dit vereist dat de gekoppelde zaaksystemen ZGW 1.5 ondersteunen.', 'owc-gravityforms-zaaksysteem'),
+                    'tooltip' => '<h6>' . __('Expand functionaliteit', 'owc-gravityforms-zaaksysteem') . '</h6>' . __('Verhoog de laadsnelheid door de expand functionaliteit te activeren. Dit vereist dat de gekoppelde zaaksystemen ZGW 1.5.0 of later ondersteunen.', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'radio',
                     'label' => esc_html__('Expand functionaliteit', 'owc-gravityforms-zaaksysteem'),
                     'choices' => [
@@ -118,9 +118,14 @@ class GravityFormsAddon extends GFAddOn
                             'value' => '0',
                         ],
                         [
-                            'name' => "{$this->prefix}-zgw-expand-enabled",
-                            'label' => __('Ingeschakeld (let op: vereist ZGW 1.5 of hoger!)', 'owc-gravityforms-zaaksysteem'),
+                            'name' => "{$this->prefix}-zgw-expand-enabled-150",
+                            'label' => __('Volgens ZGW 1.5.0', 'owc-gravityforms-zaaksysteem'),
                             'value' => '1',
+                        ],
+                        [
+                            'name' => "{$this->prefix}-zgw-expand-enabled-151",
+                            'label' => __('Volgens ZGW 1.5.1', 'owc-gravityforms-zaaksysteem'),
+                            'value' => '2',
                         ],
                     ],
                 ],

--- a/src/Http/Handlers/ExpandRequestHandler.php
+++ b/src/Http/Handlers/ExpandRequestHandler.php
@@ -56,6 +56,6 @@ class ExpandRequestHandler implements HandlerInterface
 
     protected function hasExpandedEntities(array $data): bool
     {
-        return isset($data['_expand']) && ! empty($data['_expand']);
+        return ! empty($data['_expand']);
     }
 }

--- a/src/Http/Handlers/ExpandRequestHandler.php
+++ b/src/Http/Handlers/ExpandRequestHandler.php
@@ -30,7 +30,7 @@ class ExpandRequestHandler implements HandlerInterface
         }
 
         foreach ($data['_expand'] as $name => $expandedValue) {
-            // If the original entry looks like an URL, replace it with the expanded object.
+            // If the original entry looks like a URL, replace it with the expanded object.
             if (isset($data[$name]) && is_string($data[$name]) && strpos($data[$name], 'http') !== false) {
                 $data[$name] = $expandedValue;
             }
@@ -42,7 +42,7 @@ class ExpandRequestHandler implements HandlerInterface
         }
 
         // Some expanded entities (which by now are merged into the main $data array)
-        // contain another expanded entity. We have to recursivly merge them.
+        // contain another expanded entity. We have to recursively merge them.
         foreach ($data as &$value) {
             if (is_array($value)) {
                 $value = $this->mergeExpandData($value);

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -11,14 +11,21 @@ class Response
     protected string $body;
     protected array $cookies;
     protected array $json;
+    protected string $requestUrl;
 
-    public function __construct(array $headers, array $response, string $body, array $cookies = [])
-    {
+    public function __construct(
+        array $headers,
+        array $response,
+        string $body,
+        array $cookies,
+        string $requestUrl
+    ) {
         $this->headers = $headers;
         $this->response = $response;
         $this->body = $body;
         $this->cookies = $cookies;
         $this->json = $this->parseAsJson($this->body);
+        $this->requestUrl = $requestUrl;
     }
 
     public function getHeaders(): array
@@ -61,6 +68,11 @@ class Response
     public function getParsedJson(): array
     {
         return $this->json;
+    }
+
+    public function getRequestUrl(): string
+    {
+        return $this->requestUrl;
     }
 
     protected function parseAsJson(string $body): array

--- a/src/Http/WordPress/WordPressClientResponse.php
+++ b/src/Http/WordPress/WordPressClientResponse.php
@@ -10,11 +10,19 @@ class WordPressClientResponse extends Response
 {
     public static function fromResponse(array $response): self
     {
+        $requestUrl = '';
+        if (isset($response['http_response']) && is_object($response['http_response'])) {
+            $respObj = $response['http_response']->get_response_object();
+
+            $requestUrl = $respObj->url;
+        }
+
         return new self(
             isset($response['headers']) ? $response['headers']->getAll() : [],
             $response['response'] ?? [],
             $response['body'] ?? '',
             $response['cookies'] ?? [],
+            $requestUrl
         );
     }
 }

--- a/src/Support/Enumerable.php
+++ b/src/Support/Enumerable.php
@@ -57,6 +57,7 @@ abstract class Enumerable implements ArrayAccess, Iterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->data[$offset] : null;
@@ -67,11 +68,13 @@ abstract class Enumerable implements ArrayAccess, Iterator
         reset($this->data);
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->data);
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->data);


### PR DESCRIPTION
# Nieuw:

- Expand ZGW 1.5.1 ondersteuning is toegevoegd. In de instellingen kun je nu aangeven of je 1.5.0 of 1.5.1. wilt gebruiken. De nieuwste versie ondersteunt het expanden van meer resources.
- RX.mission getest met de expand functionaliteit

# Wijzigingen:

Als de expand functionaliteit geactiveerd is, expand het enkel nog maar 'zaaktype' en 'status'. Dit in tegenstelling tot de vorige versie, waarbij alles werd ge-expand. In versie 1.5.1 zijn er heel wat resources toegevoegd die ge-expand kunnen worden, waardoor dit gedrag niet zo heel handig meer is.

De rest van de expand functionaliteit is niet gewijzigd:

_Selectief resources wel/niet expanden:_
```php
$zaak = $client->zaken()->expandExcept(['status.statustype'])->get('aaabbbbccc');
$zaak = $client->zaken()->expandOnly(['zaaktype'])->get('aaabbbbccc');
```

_Expand volledig uitzetten:_
```php
$zaak = $client->zaken()->expandNone()->get('aaabbbbccc');
```

_Alle mogelijke resoures expanden:_
```php
$zaak = $client->zaken()->expandAll()->get('aaabbbbccc');
```

Al zou ik dat laatste niet aanraden.