### PR TITLE
(feat) add supplier selection

### DIFF
--- a/config/container.php
+++ b/config/container.php
@@ -16,6 +16,9 @@ return [
      * OpenZaak configuration.
      */
     'openzaak.abbr' => 'oz',
+    'oz.enabled' => function (Container $container) {
+        return (bool) $container->make('gf.setting', ['-suppliers-openzaak-enabled']);
+    },
     'oz.client' => fn (Container $container) => $container->get(Clients\OpenZaak\Client::class),
     'oz.catalogi_uri' => function (Container $container) {
         return $container->make('gf.setting', ['-openzaak-catalogi-url']);
@@ -40,6 +43,9 @@ return [
      * Decos JOIN configuration.
      */
     'decosjoin.abbr' => 'dj',
+    'dj.enabled' => function (Container $container) {
+        return (bool) $container->make('gf.setting', ['-suppliers-decos-join-enabled']);
+    },
     'dj.client' => fn (Container $container) => $container->get(Clients\DecosJoin\Client::class),
     'dj.catalogi_uri' => function (Container $container) {
         return $container->make('gf.setting', ['-decos-join-catalogi-url']);
@@ -70,6 +76,9 @@ return [
      * RX.Mission configuration.
      */
     'rx-mission.abbr' => 'rx',
+    'rx.enabled' => function (Container $container) {
+        return (bool) $container->make('gf.setting', ['-suppliers-rx-mission-enabled']);
+    },
     'rx.client' => fn (Container $container) => $container->get(Clients\RxMission\Client::class),
     'rx.catalogi_uri' => function (Container $container) {
         return $container->make('gf.setting', ['-rx-mission-catalogi-url']);
@@ -94,6 +103,9 @@ return [
      * Xxllnc configuration.
      */
     'xxllnc.abbr' => 'xxllnc',
+    'xxllnc.enabled' => function (Container $container) {
+        return (bool) $container->make('gf.setting', ['-suppliers-xxllnc-enabled']);
+    },
     'xxllnc.client' => fn (Container $container) => $container->get(Clients\Xxllnc\Client::class),
     'xxllnc.catalogi_uri' => function (Container $container) {
         return $container->make('gf.setting', ['-xxllnc-catalogi-url']);
@@ -118,6 +130,9 @@ return [
      * Procura configuration.
      */
     'procura.abbr' => 'procura',
+    'procura.enabled' => function (Container $container) {
+        return (bool) $container->make('gf.setting', ['-suppliers-procura-enabled']);
+    },
     'procura.client' => fn (Container $container) => $container->get(Clients\Procura\Client::class),
     'procura.catalogi_uri' => function (Container $container) {
         return $container->make('gf.setting', ['-procura-catalogi-url']);

--- a/src/GravityForms/GravityFormsAddon.php
+++ b/src/GravityForms/GravityFormsAddon.php
@@ -129,6 +129,33 @@ class GravityFormsAddon extends GFAddOn
                         ],
                     ],
                 ],
+                [
+                    'name' => "{$this->prefix}-suppliers",
+                    'label' => esc_html__('Leveranciers', 'owc-gravityforms-zaaksysteem'),
+                    'type' => 'checkbox',
+                    'choices' => [
+                        [
+                            'label' => 'Decos Join',
+                            'name' => 'decos-join',
+                        ],
+                        [
+                            'label' => 'OpenZaak',
+                            'name' => 'openzaak',
+                        ],
+                        [
+                            'label' => 'Procura',
+                            'name' => 'procura',
+                        ],
+                        [
+                            'label' => 'Rx.Mission',
+                            'name' => 'rx-mission',
+                        ],
+                        [
+                            'label' => 'Xxllnc',
+                            'name' => 'xxllnc',
+                        ],
+                    ],
+                ],
             ],
         ];
     }
@@ -148,34 +175,48 @@ class GravityFormsAddon extends GFAddOn
     {
         return [
             'title' => esc_html__('OpenZaak', 'owc-gravityforms-zaaksysteem'),
+            'dependency' => [
+                'live' => true,
+                'fields' => [
+                    [
+                        'field' => "{$this->prefix}-suppliers",
+                        'values' => ['openzaak'],
+                    ],
+                ],
+            ],
             'fields' => [
                 [
                     'label' => esc_html__('Catalogi URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-openzaak-catalogi-url",
                 ],
                 [
                     'label' => esc_html__('Documenten URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-openzaak-documenten-url",
                 ],
                 [
                     'label' => esc_html__('Zaken URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-openzaak-zaken-url",
                 ],
                 [
                     'label' => esc_html__('Client ID', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-openzaak-client-id",
                 ],
                 [
                     'label' => esc_html__('Client Secret', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-openzaak-client-secret",
                 ],
@@ -187,40 +228,55 @@ class GravityFormsAddon extends GFAddOn
     {
         return [
             'title' => esc_html__('Decos Join', 'owc-gravityforms-zaaksysteem'),
+            'dependency' => [
+                'live' => true,
+                'fields' => [
+                    [
+                        'field' => "{$this->prefix}-suppliers",
+                        'values' => ['decos-join'],
+                    ],
+                ],
+            ],
             'fields' => [
                 [
                     'label' => esc_html__('Catalogi URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-decos-join-catalogi-url",
                 ],
                 [
                     'label' => esc_html__('Documenten URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-decos-join-documenten-url",
                 ],
                 [
                     'label' => esc_html__('Zaken URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-decos-join-zaken-url",
                 ],
                 [
                     'label' => esc_html__('Client ID', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-decos-join-client-id",
                 ],
                 [
                     'label' => esc_html__('Client Secret (ZTC)', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-decos-join-client-secret",
                 ],
                 [
                     'label' => esc_html__('Client Secret (ZRC)', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-decos-join-client-secret-zrc",
                 ],
@@ -232,34 +288,48 @@ class GravityFormsAddon extends GFAddOn
     {
         return [
             'title' => esc_html__('Rx.Mission', 'owc-gravityforms-zaaksysteem'),
+            'dependency' => [
+                'live' => true,
+                'fields' => [
+                    [
+                        'field' => "{$this->prefix}-suppliers",
+                        'values' => ['rx-mission'],
+                    ],
+                ],
+            ],
             'fields' => [
                 [
                     'label' => esc_html__('Catalogi URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-rx-mission-catalogi-url",
                 ],
                 [
                     'label' => esc_html__('Documenten URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-rx-mission-documenten-url",
                 ],
                 [
                     'label' => esc_html__('Zaken URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-rx-mission-zaken-url",
                 ],
                 [
                     'label' => esc_html__('Client ID', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-rx-mission-client-id",
                 ],
                 [
                     'label' => esc_html__('Client Secret', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-rx-mission-client-secret",
                 ],
@@ -271,34 +341,48 @@ class GravityFormsAddon extends GFAddOn
     {
         return [
             'title' => esc_html__('Xxllnc', 'owc-gravityforms-zaaksysteem'),
+            'dependency' => [
+                'live' => true,
+                'fields' => [
+                    [
+                        'field' => "{$this->prefix}-suppliers",
+                        'values' => ['xxllnc'],
+                    ],
+                ],
+            ],
             'fields' => [
                 [
                     'label' => esc_html__('Catalogi URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-xxllnc-catalogi-url",
                 ],
                 [
                     'label' => esc_html__('Documenten URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-xxllnc-documenten-url",
                 ],
                 [
                     'label' => esc_html__('Zaken URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-xxllnc-zaken-url",
                 ],
                 [
                     'label' => esc_html__('Client ID', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-xxllnc-client-id",
                 ],
                 [
                     'label' => esc_html__('Client Secret', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-xxllnc-client-secret",
                 ],
@@ -310,34 +394,48 @@ class GravityFormsAddon extends GFAddOn
     {
         return [
             'title' => esc_html__('Procura', 'owc-gravityforms-zaaksysteem'),
+            'dependency' => [
+                'live' => true,
+                'fields' => [
+                    [
+                        'field' => "{$this->prefix}-suppliers",
+                        'values' => ['procura'],
+                    ],
+                ],
+            ],
             'fields' => [
                 [
                     'label' => esc_html__('Catalogi URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-procura-catalogi-url",
                 ],
                 [
                     'label' => esc_html__('Documenten URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-procura-documenten-url",
                 ],
                 [
                     'label' => esc_html__('Zaken URL', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-procura-zaken-url",
                 ],
                 [
                     'label' => esc_html__('Client ID', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-procura-client-id",
                 ],
                 [
                     'label' => esc_html__('Client Secret', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'text',
+                    'required' => true,
                     'class' => 'medium',
                     'name' => "{$this->prefix}-procura-client-secret",
                 ],

--- a/src/GravityForms/GravityFormsAddon.php
+++ b/src/GravityForms/GravityFormsAddon.php
@@ -136,23 +136,23 @@ class GravityFormsAddon extends GFAddOn
                     'choices' => [
                         [
                             'label' => 'Decos Join',
-                            'name' => 'decos-join',
+                            'name' => "{$this->prefix}-suppliers-decos-join-enabled",
                         ],
                         [
                             'label' => 'OpenZaak',
-                            'name' => 'openzaak',
+                            'name' => "{$this->prefix}-suppliers-openzaak-enabled",
                         ],
                         [
                             'label' => 'Procura',
-                            'name' => 'procura',
+                            'name' => "{$this->prefix}-suppliers-procura-enabled",
                         ],
                         [
                             'label' => 'Rx.Mission',
-                            'name' => 'rx-mission',
+                            'name' => "{$this->prefix}-suppliers-rx-mission-enabled",
                         ],
                         [
                             'label' => 'Xxllnc',
-                            'name' => 'xxllnc',
+                            'name' => "{$this->prefix}-suppliers-xxllnc-enabled",
                         ],
                     ],
                 ],
@@ -180,7 +180,7 @@ class GravityFormsAddon extends GFAddOn
                 'fields' => [
                     [
                         'field' => "{$this->prefix}-suppliers",
-                        'values' => ['openzaak'],
+                        'values' => ["{$this->prefix}-suppliers-openzaak-enabled"],
                     ],
                 ],
             ],
@@ -233,7 +233,7 @@ class GravityFormsAddon extends GFAddOn
                 'fields' => [
                     [
                         'field' => "{$this->prefix}-suppliers",
-                        'values' => ['decos-join'],
+                        'values' => ["{$this->prefix}-suppliers-decos-join-enabled"],
                     ],
                 ],
             ],
@@ -293,7 +293,7 @@ class GravityFormsAddon extends GFAddOn
                 'fields' => [
                     [
                         'field' => "{$this->prefix}-suppliers",
-                        'values' => ['rx-mission'],
+                        'values' => ["{$this->prefix}-suppliers-rx-mission-enabled"],
                     ],
                 ],
             ],
@@ -346,7 +346,7 @@ class GravityFormsAddon extends GFAddOn
                 'fields' => [
                     [
                         'field' => "{$this->prefix}-suppliers",
-                        'values' => ['xxllnc'],
+                        'values' => ["{$this->prefix}-suppliers-xxllnc-enabled"],
                     ],
                 ],
             ],
@@ -399,7 +399,7 @@ class GravityFormsAddon extends GFAddOn
                 'fields' => [
                     [
                         'field' => "{$this->prefix}-suppliers",
-                        'values' => ['procura'],
+                        'values' => ["{$this->prefix}-suppliers-procura-enabled"],
                     ],
                 ],
             ],

--- a/src/GravityForms/GravityFormsFormSettings.php
+++ b/src/GravityForms/GravityFormsFormSettings.php
@@ -18,6 +18,50 @@ class GravityFormsFormSettings
      */
     public function addFormSettings(array $fields, array $form): array
     {
+        $supplierChoices = [
+            [
+                'name' => "{$this->prefix}-form-setting-supplier-none",
+                'label' => __('Selecteer leverancier', 'owc-gravityforms-zaaksysteem'),
+                'value' => 'none',
+            ],
+        ];
+        if (ContainerResolver::make()->get('oz.enabled')) {
+            $supplierChoices[] = [
+                'name' => "{$this->prefix}-form-setting-supplier-openzaak",
+                'label' => __('OpenZaak', 'owc-gravityforms-zaaksysteem'),
+                'value' => 'openzaak',
+            ];
+        }
+        if (ContainerResolver::make()->get('dj.enabled')) {
+            $supplierChoices[] = [
+                'name' => "{$this->prefix}-form-setting-supplier-decos-join",
+                'label' => __('Decos Join', 'owc-gravityforms-zaaksysteem'),
+                'value' => 'decos-join',
+            ];
+        }
+        if (ContainerResolver::make()->get('rx.enabled')) {
+            $supplierChoices[] = [
+                'name' => "{$this->prefix}-form-setting-supplier-rx-mission",
+                'label' => __('Rx.Mission', 'owc-gravityforms-zaaksysteem'),
+                'value' => 'rx-mission',
+            ];
+        }
+        if (ContainerResolver::make()->get('xxllnc.enabled')) {
+            $supplierChoices[] = [
+                'name' => "{$this->prefix}-form-setting-supplier-xxllnc",
+                'label' => __('Xxllnc', 'owc-gravityforms-zaaksysteem'),
+                'value' => 'xxllnc',
+            ];
+        }
+
+        if (ContainerResolver::make()->get('procura.enabled')) {
+            $supplierChoices[] = [
+                'name' => "{$this->prefix}-form-setting-supplier-procura",
+                'label' => __('Procura', 'owc-gravityforms-zaaksysteem'),
+                'value' => 'procura',
+            ];
+        }
+
         $fields['owc-gravityforms-zaaksysteem'] = [
             'title' => esc_html__('Zaaksysteem', 'owc-gravityforms-zaaksysteem'),
             'description' => esc_html__('Om de snelheid te verhogen worden de instellingen van leveranciers pas opgehaald na het kiezen van een leverancier. Dit betekent dat de pagina herladen moet worden na het selecteren van een leverancier.', 'owc-gravityforms-zaaksysteem'),
@@ -28,38 +72,7 @@ class GravityFormsFormSettings
                     'tooltip' => '<h6>' . __('Selecteer een leverancier', 'owc-gravityforms-zaaksysteem') . '</h6>' . __('Kies een Zaaksysteem leverancier. Let op dat je ook de instellingen van de leverancier moet configureren in de hoofdinstellingen van Gravity Forms.', 'owc-gravityforms-zaaksysteem'),
                     'type' => 'select',
                     'label' => esc_html__('Selecteer een leverancier', 'owc-gravityforms-zaaksysteem'),
-                    'choices' => [
-                        [
-                            'name' => "{$this->prefix}-form-setting-supplier-none",
-                            'label' => __('Selecteer leverancier', 'owc-gravityforms-zaaksysteem'),
-                            'value' => 'none',
-                        ],
-                        [
-                            'name' => "{$this->prefix}-form-setting-supplier-openzaak",
-                            'label' => __('OpenZaak', 'owc-gravityforms-zaaksysteem'),
-                            'value' => 'openzaak',
-                        ],
-                        [
-                            'name' => "{$this->prefix}-form-setting-supplier-decos-join",
-                            'label' => __('Decos Join', 'owc-gravityforms-zaaksysteem'),
-                            'value' => 'decos-join',
-                        ],
-                        [
-                            'name' => "{$this->prefix}-form-setting-supplier-rx-mission",
-                            'label' => __('Rx.Mission', 'owc-gravityforms-zaaksysteem'),
-                            'value' => 'rx-mission',
-                        ],
-                        [
-                            'name' => "{$this->prefix}-form-setting-supplier-xxllnc",
-                            'label' => __('Xxllnc', 'owc-gravityforms-zaaksysteem'),
-                            'value' => 'xxllnc',
-                        ],
-                        [
-                            'name' => "{$this->prefix}-form-setting-supplier-procura",
-                            'label' => __('Procura', 'owc-gravityforms-zaaksysteem'),
-                            'value' => 'procura',
-                        ],
-                    ],
+                    'choices' => $supplierChoices,
                 ],
                 [
                     'name' => "{$this->prefix}-form-setting-supplier-manually",
@@ -110,8 +123,9 @@ class GravityFormsFormSettings
      */
     protected function fieldsBySupplier(): array
     {
-        return [
-            'openzaak' => [
+        $fields = [];
+        if (ContainerResolver::make()->get('oz.enabled')) {
+            $fields['openzaak'] = [
                 'select_setting' => [
                     [
                         'name' => "{$this->prefix}-form-setting-openzaak-identifier",
@@ -190,88 +204,11 @@ class GravityFormsFormSettings
                         ],
                     ],
                 ],
-            ],
-            'decos-join' => [
-                'select_setting' => [
-                    [
-                        'name' => "{$this->prefix}-form-setting-decos-join-identifier",
-                        'type' => 'select',
-                        'label' => esc_html__('Zaaktype', 'owc-gravityforms-zaaksysteem'),
-                        'dependency' => [
-                            'live' => true,
-                            'fields' => [
-                                [
-                                    'field' => "{$this->prefix}-form-setting-supplier",
-                                    'values' => ['decos-join'],
-                                ],
-                                [
-                                    'field' => "{$this->prefix}-form-setting-supplier-manually",
-                                    'values' => ['0'],
-                                ],
-                            ],
-                        ],
-                        'choices' => (new DecosClient(ContainerResolver::make()->getApiClient('decos')))->zaaktypen(),
-                    ],
-                    [
-                        'name' => "{$this->prefix}-form-setting-decos-join-information-object-type",
-                        'type' => 'select',
-                        'label' => esc_html__('Informatie object type', 'owc-gravityforms-zaaksysteem'),
-                        'dependency' => [
-                            'live' => true,
-                            'fields' => [
-                                [
-                                    'field' => "{$this->prefix}-form-setting-supplier",
-                                    'values' => ['decos-join'],
-                                ],
-                                [
-                                    'field' => "{$this->prefix}-form-setting-supplier-manually",
-                                    'values' => ['0'],
-                                ],
-                            ],
-                        ],
-                        'choices' => (new DecosClient(ContainerResolver::make()->getApiClient('decos')))->informatieobjecttypen(),
-                    ],
-                ],
-                'manual_setting' => [
-                    [
-                        'name' => "{$this->prefix}-form-setting-decos-join-identifier-manual",
-                        'type' => 'text',
-                        'label' => esc_html__('Zaaktype', 'owc-gravityforms-zaaksysteem'),
-                        'dependency' => [
-                            'live' => true,
-                            'fields' => [
-                                [
-                                    'field' => "{$this->prefix}-form-setting-supplier",
-                                    'values' => ['decos-join'],
-                                ],
-                                [
-                                    'field' => "{$this->prefix}-form-setting-supplier-manually",
-                                    'values' => ['1'],
-                                ],
-                            ],
-                        ],
-                    ],
-                    [
-                        'name' => "{$this->prefix}-form-setting-decos-join-information-object-type-manual",
-                        'type' => 'text',
-                        'label' => esc_html__('Informatie object type', 'owc-gravityforms-zaaksysteem'),
-                        'dependency' => [
-                            'live' => true,
-                            'fields' => [
-                                [
-                                    'field' => "{$this->prefix}-form-setting-supplier",
-                                    'values' => ['decos-join'],
-                                ],
-                                [
-                                    'field' => "{$this->prefix}-form-setting-supplier-manually",
-                                    'values' => ['1'],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'rx-mission' => [
+            ];
+        }
+
+        if (ContainerResolver::make()->get('rx.enabled')) {
+            $fields['rx-mission'] = [
                 'select_setting' => [
                     [
                         'name' => "{$this->prefix}-form-setting-rx-mission-identifier",
@@ -350,8 +287,11 @@ class GravityFormsFormSettings
                         ],
                     ],
                 ],
-            ],
-            'xxllnc' => [
+            ];
+        }
+
+        if (ContainerResolver::make()->get('xxllnc.enabled')) {
+            $fields['xxllnc'] = [
                 'select_setting' => [
                     [
                         'name' => "{$this->prefix}-form-setting-xxllnc-identifier",
@@ -430,8 +370,11 @@ class GravityFormsFormSettings
                         ],
                     ],
                 ],
-            ],
-            'procura' => [
+            ];
+        }
+
+        if (ContainerResolver::make()->get('procura.enabled')) {
+            $fields['procura'] = [
                 'select_setting' => [
                     [
                         'name' => "{$this->prefix}-form-setting-procura-identifier",
@@ -510,7 +453,93 @@ class GravityFormsFormSettings
                         ],
                     ],
                 ],
-            ],
-        ];
+            ];
+        }
+
+        if (ContainerResolver::make()->get('dj.enabled')) {
+            $fields['decos-join'] = [
+                'select_setting' => [
+                    [
+                        'name' => "{$this->prefix}-form-setting-decos-join-identifier",
+                        'type' => 'select',
+                        'label' => esc_html__('Zaaktype', 'owc-gravityforms-zaaksysteem'),
+                        'dependency' => [
+                            'live' => true,
+                            'fields' => [
+                                [
+                                    'field' => "{$this->prefix}-form-setting-supplier",
+                                    'values' => ['decos-join'],
+                                ],
+                                [
+                                    'field' => "{$this->prefix}-form-setting-supplier-manually",
+                                    'values' => ['0'],
+                                ],
+                            ],
+                        ],
+                        'choices' => (new DecosClient(ContainerResolver::make()->getApiClient('decos')))->zaaktypen(),
+                    ],
+                    [
+                        'name' => "{$this->prefix}-form-setting-decos-join-information-object-type",
+                        'type' => 'select',
+                        'label' => esc_html__('Informatie object type', 'owc-gravityforms-zaaksysteem'),
+                        'dependency' => [
+                            'live' => true,
+                            'fields' => [
+                                [
+                                    'field' => "{$this->prefix}-form-setting-supplier",
+                                    'values' => ['decos-join'],
+                                ],
+                                [
+                                    'field' => "{$this->prefix}-form-setting-supplier-manually",
+                                    'values' => ['0'],
+                                ],
+                            ],
+                        ],
+                        'choices' => (new DecosClient(ContainerResolver::make()->getApiClient('decos')))->informatieobjecttypen(),
+                    ],
+                ],
+                'manual_setting' => [
+                    [
+                        'name' => "{$this->prefix}-form-setting-decos-join-identifier-manual",
+                        'type' => 'text',
+                        'label' => esc_html__('Zaaktype', 'owc-gravityforms-zaaksysteem'),
+                        'dependency' => [
+                            'live' => true,
+                            'fields' => [
+                                [
+                                    'field' => "{$this->prefix}-form-setting-supplier",
+                                    'values' => ['decos-join'],
+                                ],
+                                [
+                                    'field' => "{$this->prefix}-form-setting-supplier-manually",
+                                    'values' => ['1'],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'name' => "{$this->prefix}-form-setting-decos-join-information-object-type-manual",
+                        'type' => 'text',
+                        'label' => esc_html__('Informatie object type', 'owc-gravityforms-zaaksysteem'),
+                        'dependency' => [
+                            'live' => true,
+                            'fields' => [
+                                [
+                                    'field' => "{$this->prefix}-form-setting-supplier",
+                                    'values' => ['decos-join'],
+                                ],
+                                [
+                                    'field' => "{$this->prefix}-form-setting-supplier-manually",
+                                    'values' => ['1'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+
+        }
+
+        return $fields;
     }
 }

--- a/src/Http/RequestError.php
+++ b/src/Http/RequestError.php
@@ -5,19 +5,22 @@ declare(strict_types=1);
 namespace OWC\Zaaksysteem\Http;
 
 use Exception;
+use Throwable;
 
 class RequestError extends Exception
 {
+    protected const DEFAULT_ERROR_MESSAGE = 'A request error occurred. Additionally, no error message could be retrieved.';
+
     protected ?Response $response = null;
 
     public static function fromResponse(Response $response)
     {
         try {
             $json = $response->getParsedJson();
-            $message = sprintf('%s "%s".', $json['title'] ?? '', $json['detail'] ?? '');
+            $message = (new static())->formatResponse($json);
             $status = $json['status'] ?? 0;
-        } catch (\Throwable $e) {
-            $message = 'A request error occurred. Additionally, no error message could be retrieved.';
+        } catch (Throwable $e) {
+            $message = self::DEFAULT_ERROR_MESSAGE;
             $status = 0;
         }
 
@@ -37,5 +40,14 @@ class RequestError extends Exception
     public function getResponse(): ?Response
     {
         return $this->response;
+    }
+
+    protected function formatResponse(array $json): string
+    {
+        if (isset($json['title']) && isset($json['detail'])) {
+            return sprintf('%s "%s".', $json['title'], $json['detail']);
+        }
+
+        return self::DEFAULT_ERROR_MESSAGE;
     }
 }


### PR DESCRIPTION
- added supplier selection (GF_Addon)
- filter options on enabled suppliers
- format JSON response error message

Maar het meest belangrijke, op basis van de leverancier selectie in de algemene instellingen wordt op de pagina 'formulier instellingen' alleen de zaaktypen en informatieobject typen van de geselecteerde leveranciers opgehaald.

![Scherm­afbeelding 2024-12-11 om 17 02 34](https://github.com/user-attachments/assets/77e5c4db-3c26-4368-a833-f4864c5d95b5)
![Scherm­afbeelding 2024-12-11 om 17 02 13](https://github.com/user-attachments/assets/b467bea7-ccd6-49b0-9656-a71d368b54b3)
