### PR TITLE
(feat): Log arguments when creating submission PDC failed

### DIFF
--- a/src/Clients/DecosJoin/Actions/CreateSubmissionPDFAction.php
+++ b/src/Clients/DecosJoin/Actions/CreateSubmissionPDFAction.php
@@ -20,6 +20,11 @@ class CreateSubmissionPDFAction extends AbstractCreateSubmissionPDFAction
             return null;
         }
 
-        return $this->connectZaakToSubmissionPDF($this->createSubmissionPDF($args));
+        try {
+            return $this->connectZaakToSubmissionPDF($this->createSubmissionPDF($args));
+        } catch (\Exception $e) {
+            error_log('Creating submission PDF failed. Arguments: ' . json_encode($args));
+            throw $e;
+        }
     }
 }


### PR DESCRIPTION
Trouble shooting issues with PDF generation is difficult without seeing the request arguments.