### PR TITLE
(refactor): remove unused applying of ssl certs in abstract client class

### DIFF
--- a/src/Contracts/AbstractClient.php
+++ b/src/Contracts/AbstractClient.php
@@ -6,18 +6,13 @@ namespace OWC\Zaaksysteem\Contracts;
 
 use InvalidArgumentException;
 use OWC\Zaaksysteem\Endpoints\Endpoint;
+use function OWC\Zaaksysteem\Foundation\Helpers\resolve;
 use OWC\Zaaksysteem\Http\Errors\ResourceNotFoundError;
 use OWC\Zaaksysteem\Http\Errors\ServerError;
 use OWC\Zaaksysteem\Http\RequestClientInterface;
-use function OWC\Zaaksysteem\Foundation\Helpers\resolve;
 
 abstract class AbstractClient implements Client
 {
-    /**
-     * Some clients require the use of SSL certificates.
-     */
-    public const USE_SSL_CERTIFICATES = false;
-
     public const CLIENT_NAME = 'abstract';
 
     /**
@@ -96,35 +91,7 @@ abstract class AbstractClient implements Client
             $this->container[$key] = $endpoint;
         }
 
-        $this->applySslCertificates();
-
         return $this->container[$key];
-    }
-
-    /**
-     * Apply SSL certificates when client requires them.
-     */
-    protected function applySslCertificates(): void
-    {
-        if (! static::USE_SSL_CERTIFICATES) {
-            return;
-        }
-
-        if (! function_exists('\\Yard\\DigiD\\Foundation\\Helpers\\config')) {
-            return;
-        }
-
-        $sslPublicCert = \Yard\DigiD\Foundation\Helpers\config('digid.certificate.public');
-        $sslPrivateCert = \Yard\DigiD\Foundation\Helpers\config('digid.certificate.private');
-
-        if (! file_exists($sslPublicCert) || ! file_exists($sslPrivateCert)) {
-            return;
-        }
-
-        add_action('http_api_curl', function ($handle) use ($sslPublicCert, $sslPrivateCert) {
-            curl_setopt($handle, CURLOPT_SSLCERT, $sslPublicCert);
-            curl_setopt($handle, CURLOPT_SSLKEY, $sslPrivateCert);
-        });
     }
 
     protected function validateEndpoint(string $key): array

--- a/src/Http/WordPress/WordPressRequestClient.php
+++ b/src/Http/WordPress/WordPressRequestClient.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace OWC\Zaaksysteem\Http\WordPress;
 
-use InvalidArgumentException;
 use OWC\Zaaksysteem\Http\RequestClientInterface;
 use OWC\Zaaksysteem\Http\RequestOptions;
 use OWC\Zaaksysteem\Http\Response;
-use function Yard\DigiD\Foundation\Helpers\config;
 
 class WordPressRequestClient implements RequestClientInterface
 {
@@ -21,11 +19,15 @@ class WordPressRequestClient implements RequestClientInterface
 
     public function applyCurlSslCertificates(): self
     {
-        $sslPublicCert = config('digid.certificate.public');
-        $sslPrivateCert = config('digid.certificate.private');
+        if (! function_exists('\\Yard\\DigiD\\Foundation\\Helpers\\config')) {
+            return $this;
+        }
 
-        if (empty($sslPublicCert) || empty($sslPrivateCert)) {
-            throw new InvalidArgumentException('Missing SSL certificates: both public and private certificates are required for WordPressRequestClient configuration.');
+        $sslPublicCert = \Yard\DigiD\Foundation\Helpers\config('digid.certificate.public');
+        $sslPrivateCert = \Yard\DigiD\Foundation\Helpers\config('digid.certificate.private');
+
+        if (! file_exists($sslPublicCert) || ! file_exists($sslPrivateCert)) {
+            return $this;
         }
 
         add_action('http_api_curl', function ($handle) use ($sslPublicCert, $sslPrivateCert) {


### PR DESCRIPTION
`applySslCertificates()` is nu op plekken 2 toegevoegd maar in de container config wordt `applySslCertificates()` van de WordPressRequestClient class gebruikt en niet die van de AbstractClient class. Daar komt tevens geen enkele client bij omdat de `public const USE_SSL_CERTIFICATES = false;` door geen enkele extended class gebruikt.

Dusver is Procura de enige leverancier die dit vereist:
<img width="847" height="317" alt="Scherm­afbeelding 2025-07-24 om 13 28 27" src="https://github.com/user-attachments/assets/231f7fd7-1aba-4067-b4eb-11b6470d2c41" />
